### PR TITLE
[PKG-13105] jsonref 1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - pytest tests.py
 
 about:
-  home: http://github.com/gazpachoking/jsonref
+  home: https://github.com/gazpachoking/jsonref
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -43,7 +43,7 @@ about:
   description: |
     jsonref is a library for automatic dereferencing of JSON 
     Reference objects for Python.
-  dev_url: http://github.com/gazpachoking/jsonref
+  dev_url: https://github.com/gazpachoking/jsonref
   doc_url: https://github.com/AnacondaRecipes/jsonref-feedstock/blob/main/README.md
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,9 +27,11 @@ test:
     - tests.py
   requires:
     - pytest >=7.1.3
+    - pip
   imports:
     - jsonref
   commands:
+    - pip check
     - pytest tests.py
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,11 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: An implementation of JSON Reference for Python
+  description: |
+    jsonref is a library for automatic dereferencing of JSON 
+    Reference objects for Python.
+  dev_url: http://github.com/gazpachoking/jsonref
+  doc_url: https://github.com/AnacondaRecipes/jsonref-feedstock/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,16 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
-  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
     - pip
     - pdm-backend
     - pdm-pep517
-    - python >=3.7
+    - python
   run:
-    - python >=3.7
+    - python
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552
+  url: https://github.com/gazpachoking/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0b18f471956f60adc4cabed25fd8563237f81f2d5107e0cd0b4058110f2be100
 
 build:
   number: 0
@@ -24,8 +24,14 @@ requirements:
     - python >=3.7
 
 test:
+  source_files:
+    - tests
+  requires:
+    - pytest >=7.1.3
   imports:
     - jsonref
+  commands:
+    - pytest
 
 about:
   home: http://github.com/gazpachoking/jsonref

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,13 @@ requirements:
 
 test:
   source_files:
-    - tests
+    - tests.py
   requires:
     - pytest >=7.1.3
   imports:
     - jsonref
   commands:
-    - pytest
+    - pytest tests.py
 
 about:
   home: http://github.com/gazpachoking/jsonref


### PR DESCRIPTION
jsonref 1.1.0

**Destination channel:** defaults

### Links

- [PKG-13105]
- [Upstream repository](http://github.com/gazpachoking/jsonref)

### Explanation of changes:

- Swap to github source to run tests
- Remove noarch: python
- Fill out about section


[PKG-13105]: https://anaconda.atlassian.net/browse/PKG-13105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ